### PR TITLE
Allow SocketIOServer keywords to get passed through

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -190,8 +190,7 @@ class SocketIO(object):
             else:
                 port = 5000
         #Don't allow override of resource, otherwise allow SocketIOServer kwargs to be passed through
-        if 'resource' in kwargs:
-            kwargs.pop('resource', None)
+        kwargs.pop('resource', None)
         self.server = SocketIOServer((host, port), app.wsgi_app, resource='socket.io', **kwargs)
         if app.debug:
             @run_with_reloader


### PR DESCRIPTION
Allow keyword passthrough at run(). If there's another way to pass to app config settings, happy to go that way but this seemed the most straightforward. 
