### PR TITLE
removed gevent monkey patching

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -1,6 +1,3 @@
-from gevent import monkey
-monkey.patch_all()
-
 import os
 from socketio import socketio_manage
 from socketio.server import SocketIOServer


### PR DESCRIPTION
How necessary is the gevent monkey patching? I was having issues while running it with another threaded library ([watchdog](https://pypi.python.org/pypi/watchdog)) and disabling the monkey patching allow both to run simultaneously. The removal of the monkey patching hasn't seemed to hinder this library.