### PR TITLE
Popping broadcast off kwargs in emit.

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -202,6 +202,7 @@ class SocketIO(object):
     def emit(self, event, *args, **kwargs):
         ns_name = kwargs.pop('namespace', '')
         room = kwargs.pop('room', None)
+        broadcast = kwargs.pop('broadcast', False)
         if room is not None:
             for client in self.rooms.get(ns_name, {}).get(room, set()):
                 client.base_emit(event, *args, **kwargs)


### PR DESCRIPTION
gevent was throwing an exception about not allowing kwargs until I added this line.