### PR TITLE
Change README to reflect deprecated .ext import format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Example
 -------
 
     from flask import Flask, render_template
-    from flask.ext.socketio import SocketIO, emit
+    from flask_socketio import SocketIO, emit
     
     app = Flask(__name__)
     app.config['SECRET_KEY'] = 'secret!'


### PR DESCRIPTION
Updated example in README to move away from flask.ext imports as they will be deprecated in v1.0, see: https://github.com/mitsuhiko/flask/issues/1182