### PR TITLE
request context should not be needed when calling emit() with namespace

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -495,7 +495,10 @@ def emit(event, *args, **kwargs):
                          addressing a room, or ``False`` to send to everyone
                          but the sender.
     """
-    namespace = kwargs.get('namespace', flask.request.namespace)
+    if 'namespace' in kwargs:
+        namespace = kwargs['namespace']
+    else:
+        namespace = flask.request.namespace
     callback = kwargs.get('callback')
     broadcast = kwargs.get('broadcast')
     room = kwargs.get('room')


### PR DESCRIPTION
This pull request fixes a minor issue with `emit()`, which used to require a request context even when the namespace argument was specified. This happens because `kwargs.get()` evaluates its second argument in an eager manner. The pull request fixes this by replacing `kwargs.get()` with a membership check, falling back to the namespace of the current request context only if the `namespace` keyword argument is not present.