### PR TITLE
Improve socketio connect function for http[s]

### DIFF
--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -16,7 +16,7 @@
             // Connect to the Socket.IO server.
             // The connection URL has the following format:
             //     http[s]://<domain>:<port>[/<namespace>]
-            var socket = io.connect('http://' + document.domain + ':' + location.port + namespace);
+            var socket = io.connect(location.protocol + '//' + document.domain + ':' + location.port + namespace);
 
             // Event handler for new connections.
             // The callback function is invoked when a connection with the


### PR DESCRIPTION
Previously just the http protocol was used.
The `io.connect` function now uses `location.protocol` (creds to Miguel).
This generalizes so that the socket connection can be
made for both http and https.

https://github.com/miguelgrinberg/Flask-SocketIO/issues/335