### PR TITLE
add support for using zmq as the message queue transport

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -153,6 +153,8 @@ class SocketIO(object):
             if url:
                 if url.startswith('redis://'):
                     queue_class = socketio.RedisManager
+                elif url.startswith('zmq'):
+                    queue_class = socketio.ZmqManager
                 else:
                     queue_class = socketio.KombuManager
                 queue = queue_class(url, channel=channel,


### PR DESCRIPTION
this requires a corresponding change to python-socketio, for which I will file another pull request.