### PR TITLE
Fix 'path' or 'resource' doesn't work.

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -180,7 +180,10 @@ class SocketIO(object):
 
             self.server_options['json'] = FlaskSafeJSON
 
-        resource = kwargs.pop('path', kwargs.pop('resource', 'socket.io'))
+        # resource = kwargs.pop('path', kwargs.pop('resource', 'socket.io'))
+        resource = kwargs.pop('path', kwargs.pop('resource', '')) \
+            or self.server_options.get('path', self.server_options.get('resource')) \
+            or 'socket.io'
         if resource.startswith('/'):
             resource = resource[1:]
         self.server = socketio.Server(**self.server_options)


### PR DESCRIPTION
In this case, it works well:
> socketio = SockeIO(app, path='/path/socket.io')

While this case, it doesn't worked before the change:
> socketio = SockeIO(path='/path/socket.io')
> socketio.init_app(app)

So that this change can fix it.