### PR TITLE
Added an optional IPv6 support in eventlet

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -473,7 +473,11 @@ class SocketIO(object):
             def run_server():
                 import eventlet
                 import eventlet.wsgi
-                eventlet_socket = eventlet.listen((host, port))
+                import socket
+                addresses = socket.getaddrinfo(host, port)
+                if not addresses:
+                    raise RuntimeError('Could not resolve host to a valid address')
+                eventlet_socket = eventlet.listen(addresses[0][4], addresses[0][0])
 
                 # If provided an SSL argument, use an SSL socket
                 ssl_args = ['keyfile', 'certfile', 'server_side', 'cert_reqs',

--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -473,8 +473,8 @@ class SocketIO(object):
             def run_server():
                 import eventlet
                 import eventlet.wsgi
-                import socket
-                addresses = socket.getaddrinfo(host, port)
+                import eventlet.green
+                addresses = eventlet.green.socket.getaddrinfo(host, port)
                 if not addresses:
                     raise RuntimeError('Could not resolve host to a valid address')
                 eventlet_socket = eventlet.listen(addresses[0][4], addresses[0][0])


### PR DESCRIPTION
Eventlet forces an explicit protocol in listen(), and the default is AF_INET.
To successfully bind to '::' one has to specify AF_INET6, so this PR manages both cases.