### PR TITLE
added **kwarg to  pywsgi.WSGIServer when import WebSocketHandler failed

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -526,7 +526,7 @@ class SocketIO(object):
                     log=log, **kwargs)
             else:
                 self.wsgi_server = pywsgi.WSGIServer((host, port), app,
-                                                     log=log)
+                                                     log=log, **kwargs)
 
             if use_reloader:
                 # monkey patching is required by the reloader


### PR DESCRIPTION
there is any reason to not pass **kwarg pywsgi.WSGIServer in the case WebSocketHandler fail to import?