### PR TITLE
Add --no-reload to Flask's original run command

### DIFF
--- a/flask_socketio/cli.py
+++ b/flask_socketio/cli.py
@@ -53,6 +53,7 @@ def run(info, host, port, reload, debugger, eager_loading):
             # so we invoke Flask's original run command
             run_index = sys.argv.index('run')
             sys.argv = sys.argv[run_index:]
+            sys.argv += ['--no-reload'] if '--no-reload' not in sys.argv else []
             return run_command()
         socketio = app.extensions['socketio']
         socketio.run(app, host=host, port=port, debug=debugger,


### PR DESCRIPTION
When flask-socketio is installed but is not used in application, run ```flask run``` command will raise ```signal only works in main thread``` error. This is because ```run_with_reloader``` can already reload ```run_command``` function and it looks like this function can not be reloaded from itself again when not in main thread.

This fixed #508  and maybe also [#2200 in Flask](https://github.com/pallets/flask/issues/2200)