### PR TITLE
adding the option to setup a testclient with cookies

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -590,10 +590,11 @@ class SocketIO(object):
         """
         return self.server.sleep(seconds)
 
-    def test_client(self, app, namespace=None, query_string=None, headers=None):
+    def test_client(self, app, namespace=None, query_string=None, headers=None, cookies=None):
         """Return a simple SocketIO client that can be used for unit tests."""
         return SocketIOTestClient(app, self, namespace=namespace,
-                                  query_string=query_string, headers=headers)
+                                  query_string=query_string, headers=headers,
+                                  cookies=cookies)
 
     def _handle_event(self, handler, message, namespace, sid, *args):
         if sid not in self.server.environ:

--- a/test_socketio.py
+++ b/test_socketio.py
@@ -20,7 +20,7 @@ def on_connect():
     send('connected')
     send(json.dumps(dict(request.args)))
     send(json.dumps({h: request.headers[h] for h in request.headers.keys()
-                     if h not in ['Host', 'Content-Type', 'Content-Length']}))
+                     if h not in ['Host', 'Content-Type', 'Content-Length']}, sort_keys=True))
     send(json.dumps(request.cookies))
 
 
@@ -267,7 +267,7 @@ class TestSocketIO(unittest.TestCase):
         self.assertEqual(received[0]['args'], 'connected')
         self.assertEqual(received[1]['args'], '{"foo": ["bar", "baz"]}')
         self.assertEqual(received[2]['args'],
-                         '{"Cookie": "cookie1=foo;cookie2=bar", "Authorization": "Bearer foobar"}')
+                         '{"Authorization": "Bearer foobar", "Cookie": "cookie1=foo;cookie2=bar"}')
         self.assertEqual(received[3]['args'],
                          '{"cookie1": "foo", "cookie2": "bar"}')
         client.disconnect()


### PR DESCRIPTION
This PR allows to use test_client with cookies (as a dictionary). 