### PR TITLE
added an option to pass an existing redis connection to socketIO's init_app

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -66,6 +66,8 @@ class SocketIO(object):
                     multiple clusters of SocketIO processes need to use the
                     same message queue without interfering with each other, then
                     each cluster should use a different channel.
+    :param connection:  An existing redis connection. to be used for message
+                        queue. If missing a url will be used instead.
     :param path: The path where the Socket.IO server is exposed. Defaults to
                  ``'socket.io'``. Leave this as is unless you know what you are
                  doing.

--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -167,17 +167,17 @@ class SocketIO(object):
         if 'client_manager' not in self.server_options:
             url = self.server_options.pop('message_queue', None)
             channel = self.server_options.pop('channel', 'flask-socketio')
+            connection = self.server_options.pop('connection', None)
             write_only = app is None
-            if url:
-                if url.startswith(('redis://', "rediss://", "unix://")):
+            if connection or url:
+                if connection or url.startswith(('redis://', "rediss://")):
                     queue_class = socketio.RedisManager
                 elif url.startswith('zmq'):
                     queue_class = socketio.ZmqManager
                 else:
                     queue_class = socketio.KombuManager
-                queue = queue_class(url, channel=channel,
-                                    write_only=write_only,
-                                    **kwargs)
+                queue = queue_class(url, connection=connection, channel=channel,
+                                    write_only=write_only)
                 self.server_options['client_manager'] = queue
 
         if 'json' in self.server_options and \

--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -169,14 +169,15 @@ class SocketIO(object):
             channel = self.server_options.pop('channel', 'flask-socketio')
             write_only = app is None
             if url:
-                if url.startswith(('redis://', "rediss://")):
+                if url.startswith(('redis://', "rediss://", "unix://")):
                     queue_class = socketio.RedisManager
                 elif url.startswith('zmq'):
                     queue_class = socketio.ZmqManager
                 else:
                     queue_class = socketio.KombuManager
                 queue = queue_class(url, channel=channel,
-                                    write_only=write_only)
+                                    write_only=write_only,
+                                    **kwargs)
                 self.server_options['client_manager'] = queue
 
         if 'json' in self.server_options and \


### PR DESCRIPTION
also added the kwargs to the initialization of the queue_class
in order to pass more parameters to the initializer
in this case client_name for the redis