### PR TITLE
support --with(out)-threads for compatibility

### DIFF
--- a/flask_socketio/cli.py
+++ b/flask_socketio/cli.py
@@ -19,8 +19,11 @@ import click
 @click.option('--eager-loading/--lazy-loader', default=None,
               help='Enable or disable eager loading.  By default eager '
               'loading is enabled if the reloader is disabled.')
+@click.option('--with-threads/--without-threads', is_flag=True,
+              help='These options are only supported for compatibility with '
+              'the original Flask local development server and are ignored.')
 @pass_script_info
-def run(info, host, port, reload, debugger, eager_loading):
+def run(info, host, port, reload, debugger, eager_loading, with_threads):
     """Runs a local development server for the Flask-SocketIO application.
 
     The reloader and debugger are by default enabled if the debug flag of


### PR DESCRIPTION
In [CS50](https://cs50.harvard.edu/) (Introduction to Computer Science) at Harvard we use `Flask` in the second half of the course. We have our own customized development environment (CS50 IDE) which is a cloud-based IDE based on [Cloud9](https://github.com/c9/core) that students are encouraged to use since it allows them to try any of the code demos if they want and start working on their assignments immediately without having to worry about setting up and configuring a local development environment. 

In this environment we provide students with a wrapper around the `flask` CLI to abstract some of the complexities away from them. At the end of the course, students decide on a final project as their graduation project and they're allowed to use any environment(s) and toolset(s) that appeal. Some of them choose to work on the CS50 IDE and develop web apps that use `Flask-SocketIO`. But because our `flask` CLI wrapper passes `--with-threads` by default and `Flask-SocketIO` doesn't recognize this option, their `flask run`s fail.

I know `Flask-SocketIO` uses threads so `--with-threads` is implied, but just for compatibility with the original `flask` CLI, this PR just adds support for the `--with(out)-threads` dummy options.

cc @dmalan

#604