### PR TITLE
SocketIOTestClient can handle disconnect event from server

### DIFF
--- a/flask_socketio/test_client.py
+++ b/flask_socketio/test_client.py
@@ -45,6 +45,8 @@ class SocketIOTestClient(object):
                     pkt.packet_type == packet.BINARY_ACK:
                 self.acks[sid] = {'args': pkt.data,
                                   'namespace': pkt.namespace or '/'}
+            elif pkt.packet_type == packet.DISCONNECT:
+                self.connected[pkt.namespace or '/'] = False
 
         self.app = app
         self.flask_test_client = flask_test_client


### PR DESCRIPTION
This PR makes possible to test disconnect event from server. Now, if servers closes the connection, corresponding `connected` state is set to `False` in test client.