### PR TITLE
Flask-SocketIO 4.1.0 requires python-socketio 4.0.0 to support ConnectionRefusedError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask>=0.9',
-        'python-socketio>=2.1.0'
+        'python-socketio>=4.0.0'
     ],
     tests_require=[
         'coverage'


### PR DESCRIPTION
Hi Miguel, I've updated the minimum required version of python-socketio to 4.0.0 since that seems to be the least version which supports the ConnectionRefusedError exception.

Please, let me know if any corrections or improvements are necessary since this is my first PR.