### PR TITLE
Log when gevent is used but WebSocket is missing

### DIFF
--- a/flask_socketio/__init__.py
+++ b/flask_socketio/__init__.py
@@ -582,6 +582,9 @@ class SocketIO(object):
                 from geventwebsocket.handler import WebSocketHandler
                 websocket = True
             except ImportError:
+                app.logger.warning(
+                    'WebSocket transport not available. Install '
+                    'gevent-websocket for improved performance.')
                 websocket = False
 
             log = 'default'


### PR DESCRIPTION
Took me some time to figure out that I had to install a new dependency, since it wasn't being logged in this particular case.