### PR TITLE
Added a missing import in the example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -496,7 +496,7 @@ be created as follows::
     import functools
     from flask import request
     from flask_login import current_user
-    from flask_socketio import disconnect
+    from flask_socketio import disconnect, emit
 
     def authenticated_only(f):
         @functools.wraps(f)


### PR DESCRIPTION
`handle_my_custom_event` function uses `emit` but it wasn't imported in the mini-example