### PR TITLE
Fixing #1427

### DIFF
--- a/flask_socketio/test_client.py
+++ b/flask_socketio/test_client.py
@@ -29,6 +29,7 @@ class SocketIOTestClient(object):
     def __init__(self, app, socketio, namespace=None, query_string=None,
                  headers=None, flask_test_client=None):
         def _mock_send_packet(sid, pkt):
+            pkt.decode(pkt.encode())
             if pkt.packet_type == packet.EVENT or \
                     pkt.packet_type == packet.BINARY_EVENT:
                 if sid not in self.queue:


### PR DESCRIPTION
see issue #1427

sending data via test_client does not encode the data. So it may miss bugs like non JSON encodable data.
if the data is modified after the emit, when the test retrieves the data it will get the modified data not the data at the time it was sent