### PR TITLE
Pass URI to socket.io-client to specify namespace

### DIFF
--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -9,7 +9,8 @@
             // Connect to the Socket.IO server.
             // The connection URL has the following format, relative to the current page:
             //     http[s]://<domain>:<port>[/<namespace>]
-            var socket = io();
+		var uri = 'ws://'+window.location.hostname+':'+window.location.port+'/test';
+		var socket = io(uri);
 
             // Event handler for new connections.
             // The callback function is invoked when a connection with the


### PR DESCRIPTION
The example `app-namespace.py` which uses `templates/index.html`
did not correctly initialize the socket.io-client with the `/test`
namespace.  This prevented the client from communicating with
the example application.

This modification, constructs the URI based upon the current
`window.location`, and apppends `/test` so the client subscribes
to the correct namespace.