### PR TITLE
Only use SSL socket if kwargs are not all defaults

### DIFF
--- a/src/flask_socketio/__init__.py
+++ b/src/flask_socketio/__init__.py
@@ -607,15 +607,20 @@ class SocketIO(object):
                 eventlet_socket = eventlet.listen(addresses[0][4],
                                                   addresses[0][0])
 
-                # If provided an SSL argument, use an SSL socket
-                ssl_args = ['keyfile', 'certfile', 'server_side', 'cert_reqs',
-                            'ssl_version', 'ca_certs',
-                            'do_handshake_on_connect', 'suppress_ragged_eofs',
-                            'ciphers']
-                ssl_params = {k: kwargs[k] for k in kwargs if k in ssl_args}
-                if len(ssl_params) > 0:
-                    for k in ssl_params:
-                        kwargs.pop(k)
+                # If provided a non-default SSL argument, use an SSL socket
+                ssl_args = {'keyfile': None, 'certfile': None, 
+                            'server_side': False, 'cert_reqs': None,
+                            'ssl_version': None, 'ca_certs': None,
+                            'do_handshake_on_connect': True, 
+                            'suppress_ragged_eofs': True, 'ciphers': None}
+                ssl_params = {k: kwargs[k] for k in kwargs 
+                                if k in ssl_args.keys()}
+                non_default_ssl_params = {k: kwargs[k] for k in kwargs 
+                                if k in ssl_args.keys() and 
+                                kwargs[k] != ssl_args[k]}
+                for k in ssl_params:
+                    kwargs.pop(k)
+                if len(non_default_ssl_params) > 0:
                     ssl_params['server_side'] = True  # Listening requires true
                     eventlet_socket = eventlet.wrap_ssl(eventlet_socket,
                                                         **ssl_params)


### PR DESCRIPTION
This is just a small change to accommodate for use cases in which SSL will be used in one environment but not in the other. It allows for a configuration file to dictate SSL kwargs such as keyfile and certfile are while refraining from using SSL if the kwargs given are the default values. In my particular case that led to me changing the code I was doing exactly this (see below code snippet). I am using a configuration file to specify the location of the keyfile and certfile while running my app on my production server, but on my local machine there are no SSL files needed. Previously, the code would only check to see if SSL kwargs were provided and use an SSL socket regardless of value. Now if the SSL kwargs are provided with their default values SSL is not used.

```python
socketio.run(app, host=settings.get("flask_host", "0.0.0.0"), 
                 port=settings.get("port", 8000), 
                 debug=settings.get("debug", False), 
                 keyfile=settings.get("keyfile"), 
                 certfile=settings.get("certfile"))
```