### PR TITLE
Always pop `allow_unsafe_werkzeug` from kwargs

### DIFF
--- a/src/flask_socketio/__init__.py
+++ b/src/flask_socketio/__init__.py
@@ -632,9 +632,9 @@ class SocketIO(object):
                 from werkzeug._internal import _log
                 _log('warning', 'WebSocket transport not available. Install '
                                 'simple-websocket for improved performance.')
+            allow_unsafe_werkzeug = kwargs.pop('allow_unsafe_werkzeug',
+                                               False)
             if not sys.stdin or not sys.stdin.isatty():  # pragma: no cover
-                allow_unsafe_werkzeug = kwargs.pop('allow_unsafe_werkzeug',
-                                                   False)
                 if not allow_unsafe_werkzeug:
                     raise RuntimeError('The Werkzeug web server is not '
                                        'designed to run in production. Pass '


### PR DESCRIPTION
Running a (non-production) Flask-SocketIO app in an environment without a real shell requires to pass `allow_unsafe_werkzeug=True` into `socketio.run()`. However, adding this option results in an error when run with a real shell (e.g. for development purposes), as the option is passed to `app.run()` which then complains about it:

```
Traceback (most recent call last):
  File "dev/app.py", line 48, in <module>
    socketio.run(
  File "dev/.venv/lib/python3.10/site-packages/flask_socketio/__init__.py", line 649, in run
    app.run(host=host, port=port, threaded=True,
  File "dev/.venv/lib/python3.10/site-packages/flask/app.py", line 1188, in run
    run_simple(t.cast(str, host), port, self, **options)
TypeError: run_simple() got an unexpected keyword argument 'allow_unsafe_werkzeug'
```

There is a simple workaround for now (`sys.stdin = False`), but I'd rather fix this here by always popping the option off kwargs.

