### PR TITLE
More secure nginx configuration examples

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -95,8 +95,8 @@ proxies HTTP and WebSocket requests::
             proxy_pass http://127.0.0.1:5000;
         }
 
-        location /static {
-            alias <path-to-your-application>/static;
+        location /static/ {
+            alias <path-to-your-application>/static/;
             expires 30d;
         }
 
@@ -131,8 +131,8 @@ servers::
             proxy_pass http://127.0.0.1:5000;
         }
 
-        location /static {
-            alias <path-to-your-application>/static;
+        location /static/ {
+            alias <path-to-your-application>/static/;
             expires 30d;
         }
 


### PR DESCRIPTION
The current Nginx example configuration in the docs is potentially vulnerable.
This PR fixes that to avoid people introducing potential issues in their apps when copy-pasting that configuration.

## Explaination

This is the current configuration:

```nginx
location /static {
	alias <path-to-your-application>/static;
	expires 30d;
}
```

in case there are two separate folders, `<path-to-your-application>/static` and `<path-to-your-application>/static_secret` this setup would allow an attacker to access all the files contained in `/static_secret` just by requesting `http://[domain]/static_secret/[file]`. Adding a final slash ensures only the `static` folder is served.

```nginx
location /static/ {
	alias <path-to-your-application>/static/;
	expires 30d;
}
```

Note that as we add the slash to `alias <path-to-your-application>/static/`, it's **extremely** important that we add the final slash to `location /static/` as well, as a lack of this would lead to a much more serious path traversal vulnerability[[1]](https://www.acunetix.com/vulnerabilities/web/path-traversal-via-misconfigured-nginx-alias/)[[2]](https://i.blackhat.com/us-18/Wed-August-8/us-18-Orange-Tsai-Breaking-Parser-Logic-Take-Your-Path-Normalization-Off-And-Pop-0days-Out-2.pdf)