### PR TITLE
Fix address resolution on Solaris by specifying the protocol

### DIFF
--- a/src/flask_socketio/__init__.py
+++ b/src/flask_socketio/__init__.py
@@ -1,5 +1,6 @@
 from functools import wraps
 import os
+import socket
 import sys
 
 # make sure gevent-socketio is not installed, as it conflicts with
@@ -660,7 +661,7 @@ class SocketIO(object):
                 import eventlet
                 import eventlet.wsgi
                 import eventlet.green
-                addresses = eventlet.green.socket.getaddrinfo(host, port)
+                addresses = eventlet.green.socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
                 if not addresses:
                     raise RuntimeError(
                         'Could not resolve host to a valid address')


### PR DESCRIPTION
Hi there,

Solaris supports address resolution only if no service name (port) is specified (`None`) or if a desired protocol is explicitly specified.

```
$ python3
Python 3.9.19 (main, Mar 26 2024, 20:30:24)
[GCC 13.2.0] on sunos5
Type "help", "copyright", "credits" or "license" for more information.

>>> import socket

>>> socket.getaddrinfo("127.0.0.1", 5000)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.9/socket.py", line 954, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno 9] service name not available for the specified socket type

>>> socket.getaddrinfo("127.0.0.1", None)
[(<AddressFamily.AF_INET: 2>, 0, 0, '', ('127.0.0.1', 0))]

>>> socket.getaddrinfo("127.0.0.1", 5000, proto=socket.IPPROTO_TCP)
[(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 2>, 6, '', ('127.0.0.1', 5000))]
```

Since you seem to support only TCP anyway, I suggest specifying the protocol explicitly, like in the Python documentation:

https://docs.python.org/3/library/socket.html#socket.getaddrinfo

It doesn't hurt on any platform and fixes the resolution on Solaris. Alternatively, you can just omit the service name from the resolution. This is how the Gevent people solved the same problem: https://github.com/gevent/gevent/pull/1256 .