### PR TITLE
drop python<=3.7 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #

--- a/example/sessions.py
+++ b/example/sessions.py
@@ -12,7 +12,7 @@ Session(app)
 socketio = SocketIO(app, manage_session=False)
 
 
-class User(UserMixin, object):
+class User(UserMixin):
     def __init__(self, id=None):
         self.id = id
 

--- a/src/flask_socketio/__init__.py
+++ b/src/flask_socketio/__init__.py
@@ -33,14 +33,14 @@ class _SocketIOMiddleware(socketio.WSGIApp):
     """
     def __init__(self, socketio_app, flask_app, socketio_path='socket.io'):
         self.flask_app = flask_app
-        super(_SocketIOMiddleware, self).__init__(socketio_app,
+        super().__init__(socketio_app,
                                                   flask_app.wsgi_app,
                                                   socketio_path=socketio_path)
 
     def __call__(self, environ, start_response):
         environ = environ.copy()
         environ['flask.app'] = self.flask_app
-        return super(_SocketIOMiddleware, self).__call__(environ,
+        return super().__call__(environ,
                                                          start_response)
 
 
@@ -51,7 +51,7 @@ class _ManagedSession(dict, SessionMixin):
     pass
 
 
-class SocketIO(object):
+class SocketIO:
     """Create a Flask-SocketIO server.
 
     :param app: The flask application instance. If the application instance
@@ -204,7 +204,7 @@ class SocketIO(object):
             if url:
                 if url.startswith(('redis://', "rediss://")):
                     queue_class = socketio.RedisManager
-                elif url.startswith(('kafka://')):
+                elif url.startswith('kafka://'):
                     queue_class = socketio.KafkaManager
                 elif url.startswith('zmq'):
                     queue_class = socketio.ZmqManager
@@ -220,7 +220,7 @@ class SocketIO(object):
             # changes when it is invoked inside or outside the app context
             # so here to prevent any ambiguities we replace it with wrappers
             # that ensure that the app context is always present
-            class FlaskSafeJSON(object):
+            class FlaskSafeJSON:
                 @staticmethod
                 def dumps(*args, **kwargs):
                     with app.app_context():

--- a/src/flask_socketio/namespace.py
+++ b/src/flask_socketio/namespace.py
@@ -3,7 +3,7 @@ from socketio import Namespace as _Namespace
 
 class Namespace(_Namespace):
     def __init__(self, namespace=None):
-        super(Namespace, self).__init__(namespace)
+        super().__init__(namespace)
         self.socketio = None
 
     def _set_socketio(self, socketio):

--- a/src/flask_socketio/test_client.py
+++ b/src/flask_socketio/test_client.py
@@ -5,7 +5,7 @@ from socketio.pubsub_manager import PubSubManager
 from werkzeug.test import EnvironBuilder
 
 
-class SocketIOTestClient(object):
+class SocketIOTestClient:
     """
     This class is useful for testing a Flask-SocketIO server. It works in a
     similar way to the Flask Test Client, but adapted to the Socket.IO server.

--- a/test_socketio.py
+++ b/test_socketio.py
@@ -439,7 +439,7 @@ class TestSocketIO(unittest.TestCase):
     def test_emit_binary(self):
         client = socketio.test_client(app, auth={'foo': 'bar'})
         client.get_received()
-        client.emit('my custom event', {u'a': b'\x01\x02\x03'})
+        client.emit('my custom event', {'a': b'\x01\x02\x03'})
         received = client.get_received()
         self.assertEqual(len(received), 1)
         self.assertEqual(len(received[0]['args']), 1)


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.