### PR TITLE
Make test client accept environ_base from flask_test_client

### DIFF
--- a/src/flask_socketio/test_client.py
+++ b/src/flask_socketio/test_client.py
@@ -128,7 +128,15 @@ class SocketIOTestClient:
             if query_string[0] != '?':
                 query_string = '?' + query_string
             url += query_string
-        environ = EnvironBuilder(url, headers=headers).get_environ()
+
+        environ_base = (
+            None
+            if not self.flask_test_client
+            else self.flask_test_client.environ_base
+        )
+        environ = EnvironBuilder(
+            url, headers=headers, environ_base=environ_base
+        ).get_environ()
         environ['flask.app'] = self.app
         if self.flask_test_client:
             # inject cookies from Flask


### PR DESCRIPTION
Flask's `testing.TestClient` [sets and allows overriding its `environ_base`](https://github.com/pallets/flask/blob/85c5d93cbd049c4bd0679c36fd1ddcae8c37b642/src/flask/testing.py#L109-L133).

This PR makes flask_socketio's `SocketIOTestClient` honor the `environ_base` if it exists.

This would allow testing handler that depend on overridden `environ_base`. For example

```python
import unittest

from flask import Flask, request
from flask_socketio import SocketIO

app = Flask(__name__)
app.config["SECRET_KEY"] = "secret"
socketio = SocketIO(app)


@socketio.on("connect")
def on_connect(auth):
    return request.remote_addr == "10.0.0.0"


class TestWithClient(unittest.TestCase):
    def test_connect(self):
        flask_test_client = app.test_client()
        flask_test_client.environ_base = {
            **flask_test_client.environ_base,
            "REMOTE_ADDR": "10.0.0.0",
        }

        client = socketio.test_client(app, flask_test_client=flask_test_client)
        self.assertTrue(client.is_connected())
```