### PR TITLE
fix: replace bare except with except Exception in __init__.py

### DIFF
--- a/src/flask_socketio/__init__.py
+++ b/src/flask_socketio/__init__.py
@@ -858,7 +858,7 @@ class SocketIO:
                     ret = handler(*args)
             except ConnectionRefusedError:
                 raise  # let this error bubble up to python-socketio
-            except:
+            except Exception:
                 err_handler = self.exception_handlers.get(
                     namespace, self.default_exception_handler)
                 if err_handler is None:


### PR DESCRIPTION
The bare `except:` clause in the socket event dispatcher catches `BaseException`, which includes `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`. This means a server shutdown signal or keyboard interrupt during event handling could be silently swallowed and routed to a user error handler instead of propagating naturally.

Replace with `except Exception:` to catch only application-level exceptions while allowing system signals to propagate correctly.

**Change in `src/flask_socketio/__init__.py`:**
```python
# Before
except:
    err_handler = self.exception_handlers.get(
        namespace, self.default_exception_handler)

# After
except Exception:
    err_handler = self.exception_handlers.get(
        namespace, self.default_exception_handler)
```